### PR TITLE
Add option for setting custom classes on header

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ default: `<a class="heading-anchor" href="#%s"><span></span></a>`
 `String`: A simple way to limit this plugin to only run on files that have the provided metakey set.  
 default: `undefined`
 
+### `headingClass` (optional)
+`String`: A class that is added to the heading tag.  
+default: `undefined`
+
 ## Full example with options set
 
 Here's how to use this customized with extra css styles.

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ function plugin(options) {
   // set default options or args
   opts.allow = opts.allow || false;
   opts.linkTemplate = opts.linkTemplate || '<a class="heading-anchor" href="#%s"><span></span></a>';
+  opts.headingClass = opts.headingClass || ''
 
   return function(files, metalsmith, done) {
     setImmediate(done);
@@ -65,6 +66,9 @@ function plugin(options) {
           $(element).attr("id", id); // set the id
           idcache[id] = 1; // remember id in store
         } else {}
+
+        // add heading classes
+        $(element).addClass(opts.headingClass)
 
         // append link
         $(element).prepend(util.format(opts.linkTemplate, id));

--- a/spec/fixture/expected/headingClasses.html
+++ b/spec/fixture/expected/headingClasses.html
@@ -1,0 +1,2 @@
+<h1 id="own-id" class="headingClass"><a class="heading-anchor" href="#own-id"><span></span></a>1 heading</h1>
+<h2 id="own-h2-id" class="headingClass"><a class="heading-anchor" href="#own-h2-id"><span></span></a>2 heading</h2>

--- a/spec/fixture/src/headingClasses.html
+++ b/spec/fixture/src/headingClasses.html
@@ -1,0 +1,2 @@
+<h1 id="own-id">1 heading</h1>
+<h2 id="own-h2-id">2 heading</h2>

--- a/spec/index.js
+++ b/spec/index.js
@@ -46,4 +46,15 @@ describe('metalsmith-data-markdown', function() {
         done();
       });
   });
+  it('custom classes can be added to headings', function(done) {
+    Metalsmith('spec/fixture')
+      .use(headingsIdentifier({
+        headingClass: 'headingClass'
+      }))
+      .build(function(err) {
+        if (err) return done(err);
+        equal('spec/fixture/expected/headingClasses.html', 'spec/fixture/build/headingClasses.html');
+        done();
+      })
+  })
 });


### PR DESCRIPTION
### `headingClass` (optional)
`String`: A class that is added to the heading tag.
default: `undefined`