### PR TITLE
Options: Allow `true` as valid options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = plugin;
 
 function plugin(options) {
 
-  var opts = options || {};
+  var opts = (typeof options === 'object') && options || {};
 
   // set default options or args
   opts.allow = opts.allow || false;

--- a/spec/index.js
+++ b/spec/index.js
@@ -82,4 +82,15 @@ describe('metalsmith-headings-identifier', function() {
         done();
       });
   });
+  it('works from the CLI', function(done) {
+    // The CLI sets an expectation that `"lib": true` works correctly, with
+    // all defaults.
+    Metalsmith('spec/fixture')
+      .use(headingsIdentifier(true))
+      .build(function(err) {
+        if (err) return done(err);
+        equal('spec/fixture/expected/headingWithoutID.html', 'spec/fixture/build/headingWithoutID.html');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
The metalsmith docs imply plugins can be loaded from the CLI with `true` as the options argument. This commit adds support for that behaviour.

Added a regression test. All tests pass.